### PR TITLE
Publishing artefacts in master build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
         run: npm run build
       - name: Get current version
         run: |
-          version = $(npm pkg get version --workspaces=false | tr -d \")
+          version=$(npm pkg get version --workspaces=false | tr -d \")
           echo "version=$version" >> "$GITHUB_ENV"
-          nodeVersion = $(node -v)
+          nodeVersion=$(node -v)
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
         run: npm run build
       - name: Get current version
         run: |
-          $version = $(npm pkg get version --workspaces=false | tr -d \")
+          version = $(npm pkg get version --workspaces=false | tr -d \")
           echo "version=$version" >> "$GITHUB_ENV"
-          $nodeVersion = $(node -v)
+          nodeVersion = $(node -v)
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,14 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Get current version
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           version=$(npm pkg get version --workspaces=false | tr -d \")
           echo "version=$version" >> "$GITHUB_ENV"
           nodeVersion=$(node -v)
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v2
         with:
           name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'
-          path: dist\money-management
+          path: dist/money-management

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request: 
+  pull_request:
     branches:
       - master
 
@@ -24,4 +24,14 @@ jobs:
         run: npm ci
       - name: Build project
         run: npm run build
-        
+      - name: Get current version
+        run: |
+          $version = $(npm pkg get version --workspaces=false | tr -d \")
+          echo "version=$version" >> "$GITHUB_ENV"
+          $nodeVersion = $(node -v)
+          echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'
+          path: dist\money-management


### PR DESCRIPTION
### Description of issue

Need to implement logic to publish produced build to artefacts

### Description of fix

- added step to get current version of product and current version of node
- added step to publish build to artefacts with name `dist-{build_version}-node-{node_version}`
- publishing is performed only in `master` build