### PR TITLE
Introduce CI build for mock-server

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - .github/**
+      - mock-server/**
 
 jobs:
   build:

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -1,0 +1,19 @@
+name: App Build
+
+run-name: App Build @${{ github.sha }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: App Build
+    uses: ./.github/workflows/build.yml
+    with:
+      node-version: 16.x
+      dist-path: dist/money-management

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -17,3 +17,4 @@ jobs:
     with:
       node-version: 16.x
       dist-path: dist/money-management
+      artifact-prefix: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,15 @@
-name: Build
-
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+      root-path:
+        required: false
+        type: string
+      dist-path:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -16,10 +19,15 @@ jobs:
       node-version: 16.x
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ env.node-version }}
+      - name: Set root
+        if: ${{ github.event.inputs.root-path != '' }}
+        run: cd $ROOT_PATH
+        env:
+          ROOT_PATH: ${{ inputs.root-path }}
+      - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ inputs.node-version }}
       - name: Install packages
         run: npm ci
       - name: Build project
@@ -36,4 +44,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'
-          path: dist/money-management
+          path: ${{ inputs.dist-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set root
-        if: ${{ github.event.inputs.root-path != '' }}
+        if: ${{ inputs.root-path != '' }}
         run: cd $ROOT_PATH
         env:
           ROOT_PATH: ${{ inputs.root-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install packages
         run: npm ci
       - name: Run lint
-        if: ${{ inputs.run-lint == 'true' }}
+        if: ${{ inputs.run-lint == true }}
         run: npm run lint
       - name: Build project
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,12 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Get current version
-        if: ${{ github.event_name != 'pull_request' }}
         run: |
           version=$(npm pkg get version --workspaces=false | tr -d \")
           echo "version=$version" >> "$GITHUB_ENV"
           nodeVersion=$(node -v)
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v2
         with:
           name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set root
         if: ${{ inputs.root-path != '' }}
-        run: cd $ROOT_PATH
+        run: |
+          cd $ROOT_PATH
+          echo Root directory set to $(pwd)
         env:
           ROOT_PATH: ${{ inputs.root-path }}
       - name: Use Node.js ${{ inputs.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Get current version
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           version=$(npm pkg get version --workspaces=false | tr -d \")
           echo "version=$version" >> "$GITHUB_ENV"
@@ -47,6 +48,7 @@ jobs:
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
         uses: actions/upload-artifact@v3
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: '${{ inputs.artifact-prefix }}-${{ env.version }}-node-${{ env.nodeVersion }}'
           path: ${{ inputs.root-path }}/${{ inputs.dist-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       dist-path:
         required: true
         type: string
+      artifact-prefix:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -38,5 +41,5 @@ jobs:
       - name: Publish Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'
+          name: '${{ inputs.artifact-prefix }}-${{ env.version }}-node-${{ env.nodeVersion }}'
           path: ${{ inputs.root-path }}/${{ inputs.dist-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       root-path:
         required: false
         type: string
+        default: .
       dist-path:
         required: true
         type: string
@@ -15,29 +16,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      node-version: 16.x
+    defaults:
+      run:
+        working-directory: ${{ inputs.root-path }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set root
-        if: ${{ inputs.root-path != '' }}
-        run: |
-          cd $ROOT_PATH
-          echo Root directory set to $(pwd)
-        env:
-          ROOT_PATH: ${{ inputs.root-path }}
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.node-version }}
       - name: Install packages
-        run: |
-          pwd
-          npm ci
+        run: npm ci
       - name: Build project
-        run:
-          pwd
-          npm run build
+        run: npm run build
       - name: Get current version
         if: ${{ github.event_name != 'pull_request' }}
         run: |
@@ -50,4 +41,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'dist-${{ env.version }}-node-${{ env.nodeVersion }}'
-          path: ${{ inputs.dist-path }}
+          path: ${{ inputs.root-path }}/${{ inputs.dist-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,13 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
       - name: Install packages
-        run: npm ci
+        run: |
+          pwd
+          npm ci
       - name: Build project
-        run: npm run build
+        run:
+          pwd
+          npm run build
       - name: Get current version
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           nodeVersion=$(node -v)
           echo "nodeVersion=$nodeVersion" >> "$GITHUB_ENV"
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: '${{ inputs.artifact-prefix }}-${{ env.version }}-node-${{ env.nodeVersion }}'
           path: ${{ inputs.root-path }}/${{ inputs.dist-path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,20 @@ on:
       node-version:
         required: true
         type: string
-      root-path:
-        required: false
-        type: string
-        default: .
       dist-path:
         required: true
         type: string
       artifact-prefix:
         required: true
         type: string
+      root-path:
+        required: false
+        type: string
+        default: .
+      run-lint:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -30,6 +34,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Install packages
         run: npm ci
+      - name: Run lint
+        if: ${{ inputs.run-lint == 'true' }}
+        run: npm run lint
       - name: Build project
         run: npm run build
       - name: Get current version

--- a/.github/workflows/mock-server-build.yml
+++ b/.github/workflows/mock-server-build.yml
@@ -19,3 +19,4 @@ jobs:
       root-path: mock-server
       dist-path: build
       artifact-prefix: mock-server
+      run-lint: true

--- a/.github/workflows/mock-server-build.yml
+++ b/.github/workflows/mock-server-build.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - mock-server/**
 
 jobs:
   build:

--- a/.github/workflows/mock-server-build.yml
+++ b/.github/workflows/mock-server-build.yml
@@ -1,0 +1,20 @@
+name: Mock Server Build
+
+run-name: Mock Server Build @${{ github.sha }}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Mock Server Build
+    uses: ./.github/workflows/build.yml
+    with:
+      node-version: 16.x
+      root-path: mock-server
+      dist-path: build

--- a/.github/workflows/mock-server-build.yml
+++ b/.github/workflows/mock-server-build.yml
@@ -18,3 +18,4 @@ jobs:
       node-version: 16.x
       root-path: mock-server
       dist-path: build
+      artifact-prefix: mock-server

--- a/mock-server/package-lock.json
+++ b/mock-server/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^4.18.2"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/node": "^20.2.5",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -339,6 +340,15 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3625,6 +3635,15 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -15,6 +15,7 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/node": "^20.2.5",
     "@typescript-eslint/eslint-plugin": "^5.59.11",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ const routes: Routes = [{
   path: 'expenses',
   loadChildren: () => import('./modules/expenses/expenses.module').then((module) => module.ExpensesModule)
 }];
-// dummy change
+
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ const routes: Routes = [{
   path: 'expenses',
   loadChildren: () => import('./modules/expenses/expenses.module').then((module) => module.ExpensesModule)
 }];
-
+// dummy change
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]


### PR DESCRIPTION
### Description of issue

Need to add CI build for `mock-server` which is needed to be run in PRs and on push into `master`

### Description of fix

- made `build.yml` universal which takes follow parameters:
  - `node-version`: version of node which is used to build
  - `dist-path`: path to generated build to publish it in artefacts
  - `artifact-prefix`: prefix for artifact name
  - `root-path`: (optional) root path. If not specified then root folder will be used
  - `run-lint`: (optional) determines if command `npm run lint` will be performed before build
- added file `app-build.yml` to build angular project
- added file `mock-server-build.yml` to build `mock-server` project